### PR TITLE
chore: rename Application to JobApplication and applications to job_a…

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,4 +1,4 @@
-class Application < ApplicationRecord
+class JobApplication < ApplicationRecord
   belongs_to :user
   belongs_to :job
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -1,6 +1,6 @@
 class Job < ApplicationRecord
   belongs_to :employer
-  has_many :applications, dependent: :destroy
+  has_many :job_applications, dependent: :destroy
 
   validates :title, :description, :location, :requirements, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,8 @@ class User < ApplicationRecord
   # Associations
   has_one :candidate, dependent: :destroy
   has_one :employer, dependent: :destroy
-  has_many :applications, dependent: :destroy
-  has_many :jobs, through: :applications
+  has_many :job_applications, dependent: :destroy
+  has_many :jobs, through: :job_applications
   has_many :event_registrations, dependent: :destroy
   has_many :jobs, through: :event_registrations
   has_many :user_disabilities, dependent: :destroy

--- a/db/migrate/20240725121124_rename_applications_to_job_applications.rb
+++ b/db/migrate/20240725121124_rename_applications_to_job_applications.rb
@@ -1,0 +1,5 @@
+class RenameApplicationsToJobApplications < ActiveRecord::Migration[7.1]
+  def change
+    rename_table :applications, :job_applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_040526) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_121124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "applications", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.bigint "job_id", null: false
-    t.string "status"
-    t.datetime "applied_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["job_id"], name: "index_applications_on_job_id"
-    t.index ["user_id"], name: "index_applications_on_user_id"
-  end
 
   create_table "candidate_skills", force: :cascade do |t|
     t.bigint "candidate_id", null: false
@@ -111,6 +100,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_040526) do
     t.index ["candidate_id"], name: "index_experiences_on_candidate_id"
   end
 
+  create_table "job_applications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "job_id", null: false
+    t.string "status"
+    t.datetime "applied_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["job_id"], name: "index_job_applications_on_job_id"
+    t.index ["user_id"], name: "index_job_applications_on_user_id"
+  end
+
   create_table "jobs", force: :cascade do |t|
     t.bigint "employer_id", null: false
     t.string "title"
@@ -160,8 +160,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_040526) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "applications", "jobs"
-  add_foreign_key "applications", "users"
   add_foreign_key "candidate_skills", "candidates"
   add_foreign_key "candidate_skills", "skills"
   add_foreign_key "candidates", "users"
@@ -171,6 +169,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_040526) do
   add_foreign_key "event_registrations", "users"
   add_foreign_key "events", "employers"
   add_foreign_key "experiences", "candidates"
+  add_foreign_key "job_applications", "jobs"
+  add_foreign_key "job_applications", "users"
   add_foreign_key "jobs", "employers"
   add_foreign_key "user_disabilities", "disabilities"
   add_foreign_key "user_disabilities", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,10 +43,10 @@ events << Event.create!(employer_id: employers.last.id, name: 'UX Design Fundame
 events << Event.create!(employer_id: employers.last.id, name: 'Digital Marketing Strategies', description: 'An intensive workshop covering SEO, content marketing, and social media strategies.', location: 'New York, NY', start_time: DateTime.new(2024, 9, 12, 9, 0, 0), end_time: DateTime.new(2024, 9, 14, 17, 0, 0))
 
 # Create Applications
-applications = []
+job_applications = []
 users.select { |u| u.role == 'candidate' }.each do |user|
   jobs.sample(2).each do |job|
-    applications << Application.create!(user_id: user.id, job_id: job.id, status: 'Applied', applied_at: DateTime.now)
+    job_applications << JobApplication.create!(user_id: user.id, job_id: job.id, status: 'Applied', applied_at: DateTime.now)
   end
 end
 


### PR DESCRIPTION
Rename Application to JobApplication and applications to job_applications

Updated all references from Application to JobApplication and applications to job_applications across the codebase. This includes model names, table names, and related associations.