### PR TITLE
migrate: removed applied_at from job_applications as it is effectivel…

### DIFF
--- a/db/migrate/20240727162203_remove_applied_at_from_job_applications.rb
+++ b/db/migrate/20240727162203_remove_applied_at_from_job_applications.rb
@@ -1,0 +1,5 @@
+class RemoveAppliedAtFromJobApplications < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :job_applications, :applied_at, :datetime
+  end
+end


### PR DESCRIPTION
…y the same as created at and therefore redundant